### PR TITLE
Enable field properties to be exported too.

### DIFF
--- a/MSAccess-VCS/VCS_Table.bas
+++ b/MSAccess-VCS/VCS_Table.bas
@@ -76,7 +76,8 @@ Public Sub VCS_ExportTableDef(ByVal TableName As String, ByVal directory As Stri
     Application.ExportXML _
     ObjectType:=acExportTable, _
     DataSource:=TableName, _
-    SchemaTarget:=fileName
+    SchemaTarget:=fileName, _
+    OtherFlags:=acExportAllTableAndFieldProperties
     
     'exort Data Macros
     VCS_DataMacro.VCS_ExportDataMacros TableName, directory


### PR DESCRIPTION
So far field properties such as descriptions, lookup fields, required,  etc. are not with the table's structure. This small change includes these properties with the export and allows for a more complete reconstruction of the database's tables.